### PR TITLE
feat: メール認証の実装

### DIFF
--- a/golang_eikan/controllers/register_controller.go
+++ b/golang_eikan/controllers/register_controller.go
@@ -23,11 +23,10 @@ func Home(w http.ResponseWriter, r *http.Request) {
 	w.Write(res)
 }
 
-// Register ユーザー登録
-func Register(w http.ResponseWriter, r *http.Request) {
-	// validation
+// RegisterEmail メールアドレスの登録
+func RegisterEmail(w http.ResponseWriter, r *http.Request) {
 	body, _ := ioutil.ReadAll(r.Body)
-	err := validations.ValidateRegister(body)
+	err := validations.ValidateEmail(body)
 
 	if err != nil {
 		utils.ErrorLog("Input validation error", err)
@@ -35,16 +34,16 @@ func Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// userをdbに保存
-	err = models.RegisterUser(body)
+	// 認証用レコードを保存
+	err = models.RegisterEmail(body)
 	if err != nil {
-		utils.ErrorLog("User cannot be created", err)
+		utils.ErrorLog("Verify code cannot be created", err)
 		utils.ReturnInternalServerError(w)
 		return
 	}
 
 	// 保存した後
-	res, err := utils.NewResponse("User has been created")
+	res, err := utils.NewMessageResponse("Verify code has been sent")
 	if err != nil {
 		utils.ErrorLog("Cannot marshal to json", err)
 		utils.ReturnInternalServerError(w)

--- a/golang_eikan/controllers/user_controller.go
+++ b/golang_eikan/controllers/user_controller.go
@@ -1,0 +1,40 @@
+package controllers
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ksrnnb/eikan/models"
+	"github.com/ksrnnb/eikan/utils"
+	"github.com/ksrnnb/eikan/validations"
+)
+
+// Register ユーザー登録
+func Register(w http.ResponseWriter, r *http.Request) {
+	// validation
+	body, _ := ioutil.ReadAll(r.Body)
+	err := validations.ValidateRegister(body)
+
+	if err != nil {
+		utils.ErrorLog("Input validation error", err)
+		utils.ReturnValidationError(w)
+		return
+	}
+
+	// userをdbに保存
+	err = models.RegisterUser(body)
+	if err != nil {
+		utils.ErrorLog("User cannot be created", err)
+		utils.ReturnInternalServerError(w)
+		return
+	}
+
+	res, err := utils.NewMessageResponse("User has been created")
+	if err != nil {
+		utils.ErrorLog("Cannot marshal to json", err)
+		utils.ReturnInternalServerError(w)
+		return
+	}
+
+	utils.WriteResponse(w, res, http.StatusCreated)
+}

--- a/golang_eikan/controllers/verify_code_controller.go
+++ b/golang_eikan/controllers/verify_code_controller.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ksrnnb/eikan/models"
+	"github.com/ksrnnb/eikan/utils"
+	"github.com/ksrnnb/eikan/validations"
+)
+
+// VerifyCode ...
+func VerifyCode(w http.ResponseWriter, r *http.Request) {
+	body, _ := ioutil.ReadAll(r.Body)
+	err := validations.ValidateVerifyCode(body)
+
+	if err != nil {
+		utils.ErrorLog("Input validation error", err)
+		utils.ReturnValidationError(w)
+		return
+	}
+
+	// レコードを認証、usersテーブルに保存。
+	userToken, err := models.VerifyCode(body)
+	if err != nil {
+		utils.ErrorLog("No verify code found", err)
+		utils.ReturnInternalServerError(w)
+		return
+	}
+
+	responseMap := map[string]string{
+		"message":   "Email has been verified",
+		"userToken": userToken,
+	}
+
+	res, err := json.Marshal(responseMap)
+	if err != nil {
+		utils.ErrorLog("Cannot marshal to json", err)
+		utils.ReturnInternalServerError(w)
+		return
+	}
+
+	utils.WriteResponse(w, res, http.StatusCreated)
+}

--- a/golang_eikan/main.go
+++ b/golang_eikan/main.go
@@ -28,6 +28,8 @@ func main() {
 	r := mux.NewRouter()
 	s := r.PathPrefix(version).Subrouter()
 	s.HandleFunc("", controllers.Home)
+	s.HandleFunc("/email", controllers.RegisterEmail)
+	s.HandleFunc("/code", controllers.VerifyCode)
 	s.HandleFunc("/register", controllers.Register)
 	http.Handle("/", s)
 	http.ListenAndServe(port, nil)

--- a/golang_eikan/models/common.go
+++ b/golang_eikan/models/common.go
@@ -1,0 +1,19 @@
+package models
+
+import (
+	"log"
+
+	"github.com/ksrnnb/eikan/db"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func collection(collectionName string) *mongo.Collection {
+	database, err := db.ConnectEikanDB()
+
+	if err != nil {
+		log.Printf("DB connection error: %v", err)
+		return nil
+	}
+
+	return database.Collection(collectionName)
+}

--- a/golang_eikan/models/verify.go
+++ b/golang_eikan/models/verify.go
@@ -1,0 +1,81 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/ksrnnb/eikan/utils"
+)
+
+// Verify model
+// bsonも設定しておく。
+// insertするときに内部でbsonにMarshalするので、そのときに空の場合は省略される。
+type Verify struct {
+	ID        string    `json:"_id,omitempty" bson:"_id,omitempty"`
+	Email     string    `json:"email" bson:"email"`
+	Code      string    `json:"code" bson:"code"`
+	CreatedAt time.Time `json:"createdAt" bson:"createdAt,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt" bson:"updatedAt,omitempty"`
+}
+
+// VerifyCode ...
+func VerifyCode(requestBody []byte) (string, error) {
+	var verify Verify
+	err := json.Unmarshal(requestBody, &verify)
+
+	if err != nil {
+		return "", err
+	}
+
+	// 認証レコードを削除
+	err = verify.Delete()
+	if err != nil {
+		utils.ErrorLog("ERROR", err)
+		return "", err
+	}
+
+	// ユーザーを登録
+	user := User{Email: verify.Email}
+	err = user.Create()
+
+	return user.UserToken, err
+}
+
+// RegisterEmail register email
+func RegisterEmail(requestBody []byte) error {
+	var verify Verify
+	err := json.Unmarshal(requestBody, &verify)
+
+	if err != nil {
+		return err
+	}
+
+	// 認証レコード作成
+	err = verify.Create()
+	return err
+}
+
+// Create creates new verify code
+func (verify *Verify) Create() error {
+	verify.CreatedAt = utils.CurrentTime()
+	verify.UpdatedAt = utils.CurrentTime()
+	verify.Code = utils.GenerateVerifyCode()
+
+	_, err := collection("verify_users").InsertOne(context.Background(), verify)
+
+	return err
+}
+
+// Delete delete verify code
+func (verify *Verify) Delete() error {
+
+	result, err := collection("verify_users").DeleteOne(context.Background(), verify)
+
+	if result.DeletedCount == 0 {
+		return errors.New("verify record didn't exist")
+	}
+
+	return err
+}

--- a/golang_eikan/utils/functions.go
+++ b/golang_eikan/utils/functions.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"fmt"
+	"math/rand"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -15,4 +17,32 @@ func CurrentTime() time.Time {
 func GenerateHashedPassword(password string) string {
 	hash, _ := bcrypt.GenerateFromPassword([]byte(password), 10)
 	return string(hash)
+}
+
+// GenerateVerifyCode makes 6 digit number
+func GenerateVerifyCode() string {
+	rand.Seed(time.Now().UnixNano())
+	random := rand.Intn(1000000)
+	code := fmt.Sprintf("%06d", random)
+
+	return code
+}
+
+// GenerateToken makes 32 digit random string
+func GenerateToken() string {
+	token := randomString(32)
+	return token
+}
+
+func randomString(digit int) string {
+	rand.Seed(time.Now().UnixNano())
+	str := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	var result string
+	for i := 0; i < digit; i++ {
+		n := rand.Intn(len(str))
+		result = result + string(str[n])
+	}
+
+	return result
 }

--- a/golang_eikan/utils/message.go
+++ b/golang_eikan/utils/message.go
@@ -14,8 +14,8 @@ func NewMessage(message string) *Message {
 	return &Message{Message: message}
 }
 
-// NewResponse create new resonse with message
-func NewResponse(message string) ([]byte, error) {
+// NewMessageResponse create new resonse with message
+func NewMessageResponse(message string) ([]byte, error) {
 	msg := NewMessage(message)
 	res, err := json.Marshal(msg)
 

--- a/golang_eikan/utils/response.go
+++ b/golang_eikan/utils/response.go
@@ -13,14 +13,14 @@ func WriteResponse(w http.ResponseWriter, jsonResponse []byte, status int) {
 
 // ReturnInternalServerError returns error response
 func ReturnInternalServerError(w http.ResponseWriter) {
-	res, _ := NewResponse("Internal Server Error")
+	res, _ := NewMessageResponse("Internal Server Error")
 
 	WriteResponse(w, res, http.StatusInternalServerError)
 }
 
 // ReturnValidationError returns error response
 func ReturnValidationError(w http.ResponseWriter) {
-	res, _ := NewResponse("Validation Error")
+	res, _ := NewMessageResponse("Validation Error")
 
 	WriteResponse(w, res, http.StatusBadRequest)
 }

--- a/golang_eikan/utils/rules.go
+++ b/golang_eikan/utils/rules.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -12,4 +13,12 @@ func IsDate(fl validator.FieldLevel) bool {
 	_, err := time.Parse(time.RFC3339[:len(date)], date)
 
 	return err == nil
+}
+
+// IsCode checks its arguments is 6 digit nubmer or not
+func IsCode(fl validator.FieldLevel) bool {
+	code := fl.Field().String()
+	matched, _ := regexp.Match(`\d{6}`, []byte(code))
+
+	return matched
 }

--- a/golang_eikan/validations/register.go
+++ b/golang_eikan/validations/register.go
@@ -9,7 +9,6 @@ import (
 
 // Register struct のvalidateタグがバリデーションルール
 type Register struct {
-	Email      string `json:"email" validate:"required,email,lte=255"`
 	Password   string `json:"password" validate:"required,lte=255"`
 	Birthday   string `json:"birthday" validate:"required,is-date"`
 	GenderType int    `json:"genderType" validate:"required,lte=5"`

--- a/golang_eikan/validations/register_email.go
+++ b/golang_eikan/validations/register_email.go
@@ -1,0 +1,24 @@
+package validations
+
+import (
+	"encoding/json"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// RegisterEmail struct のvalidateタグがバリデーションルール
+type RegisterEmail struct {
+	Email string `json:"email" validate:"required,email,lte=255"`
+}
+
+// ValidateEmail validates post parameter
+func ValidateEmail(body []byte) error {
+	validate := validator.New()
+
+	var myValidator RegisterEmail
+	json.Unmarshal(body, &myValidator)
+
+	err := validate.Struct(myValidator)
+
+	return err
+}

--- a/golang_eikan/validations/register_test.go
+++ b/golang_eikan/validations/register_test.go
@@ -8,7 +8,6 @@ import (
 
 func TestValidPattern(t *testing.T) {
 	pattern := Register{
-		Email:      "test@test.com",
 		Password:   "password",
 		Birthday:   "1999-11-11",
 		GenderType: 1,
@@ -21,46 +20,16 @@ func TestValidPattern(t *testing.T) {
 	}
 }
 
-func TestInvalidEmail(t *testing.T) {
-	pattern := Register{
-		Email:      "test@test",
-		Password:   "password",
-		Birthday:   "1999-11-11",
-		GenderType: 1,
-	}
-
-	data, _ := json.Marshal(pattern)
-
-	if ValidateRegister(data) == nil {
-		t.Errorf("Email is incorrect but validation function didn't validate")
-	}
-}
-
 func TestTooLongStr(t *testing.T) {
 	tooLongStr := strings.Repeat("a", 256)
-	tooLongEmail := tooLongStr + "@test.com"
 
 	pattern := Register{
-		Email:      tooLongEmail,
-		Password:   "password",
-		Birthday:   "1999-11-11",
-		GenderType: 1,
-	}
-
-	data, _ := json.Marshal(pattern)
-
-	if ValidateRegister(data) == nil {
-		t.Errorf("Email is too long but validation function didn't validate")
-	}
-
-	pattern = Register{
-		Email:      "test@test.com",
 		Password:   tooLongStr,
 		Birthday:   "1999-11-11",
 		GenderType: 1,
 	}
 
-	data, _ = json.Marshal(pattern)
+	data, _ := json.Marshal(pattern)
 
 	if ValidateRegister(data) == nil {
 		t.Errorf("password is too long but validation function didn't validate")
@@ -69,7 +38,6 @@ func TestTooLongStr(t *testing.T) {
 
 func TestInvalidDate(t *testing.T) {
 	pattern := Register{
-		Email:      "test@test",
 		Password:   "password",
 		Birthday:   "1999-02-29",
 		GenderType: 1,
@@ -84,7 +52,6 @@ func TestInvalidDate(t *testing.T) {
 
 func TestInvalidGenderType(t *testing.T) {
 	pattern := Register{
-		Email:      "test@test.com",
 		Password:   "password",
 		Birthday:   "1999-11-11",
 		GenderType: 10,

--- a/golang_eikan/validations/verify_code.go
+++ b/golang_eikan/validations/verify_code.go
@@ -1,0 +1,31 @@
+package validations
+
+import (
+	"encoding/json"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/ksrnnb/eikan/utils"
+)
+
+// VerifyCode struct のvalidateタグがバリデーションルール
+type VerifyCode struct {
+	Email string `json:"email" validate:"required,email,lte=255"`
+	Code  string `json:"code" validate:"required,is-code"`
+}
+
+// ValidateVerifyCode validates input
+func ValidateVerifyCode(body []byte) error {
+	validate := validator.New()
+
+	err := validate.RegisterValidation("is-code", utils.IsCode)
+
+	if err != nil {
+		return err
+	}
+	var myValidator VerifyCode
+	json.Unmarshal(body, &myValidator)
+
+	err = validate.Struct(myValidator)
+
+	return err
+}


### PR DESCRIPTION
メールの送信自体は未実装。

- メールアドレス登録時に認証コードを発行
- メールアドレスと認証コードがAPIに送られると、認証完了
- 認証完了時に、usersのドキュメントを作成、トークン発行
